### PR TITLE
Host static from root

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'backend.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR,'static')],
+        'DIRS': [os.path.join(BASE_DIR, 'static')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -118,9 +118,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
 
-STATIC_URL = '/static/'
+STATIC_URL = '/django-static/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
-#STATIC_ROOT = os.path.join(BASE_DIR, './static/')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/src/backend/urls.py
+++ b/src/backend/urls.py
@@ -14,12 +14,13 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include, re_path
-from .views import index
+from django.urls import include, path, re_path
+from .views import static_files
+
 
 urlpatterns = [
     path('api/', include('api.urls')),
     path('admin/', admin.site.urls),
-    #path('', index),
-    re_path(r'^(?!api|admin)(?!...$).*$', index)
+
+    re_path(r'^(?!api|admin)(?!...$).*$', static_files)
 ]

--- a/src/backend/views.py
+++ b/src/backend/views.py
@@ -9,8 +9,6 @@ def static_files(request: HttpRequest) -> HttpResponse:
     """
     path = request.path
 
-    print("AAAAA" + path)
-
     if should_return_index(path):
         return render(request, 'index.html')
 

--- a/src/backend/views.py
+++ b/src/backend/views.py
@@ -1,4 +1,33 @@
+import mimetypes
+from django.http import FileResponse, HttpRequest, HttpResponse
 from django.shortcuts import render
 
-def index(request):
-    return render(request, 'index.html')
+
+def static_files(request: HttpRequest) -> HttpResponse:
+    """
+    Returns the static file at the given path, or the index.html file when appropriate.
+    """
+    path = request.path
+
+    print("AAAAA" + path)
+
+    if should_return_index(path):
+        return render(request, 'index.html')
+
+    else:
+        try:
+            static_path = path[1:]
+            file = open('src/static/' + static_path, 'rb')
+        except FileNotFoundError:
+            return HttpResponse(status=404)
+
+        type = mimetypes.guess_type(path)[0]
+
+        return FileResponse(file, content_type=type)
+
+
+def should_return_index(path: str) -> bool:
+    """
+    Returns true if the given path should return the index.html file.
+    """
+    return path == "/" or path == "/index.html" or '.' not in path


### PR DESCRIPTION
Ändrade så att webbapplikationen är hostad i root URL:en, istället för i /static.
Det betyder också att frontend inte behöver sätta "homepage"="static".